### PR TITLE
double-quote \t to mean tab (and not slash-t )

### DIFF
--- a/utils/arup_archive.py
+++ b/utils/arup_archive.py
@@ -75,7 +75,7 @@ subyt:
   - source: 
       path: ./results/taxonomy-summary/SSU/{PREFIX}.merged_SSU.fasta.mseq.tsv
       mime: text/csv
-      delimiter: \\t
+      delimiter: "\t"
       header: OTU_ID\\tSSU_rRNA\\ttaxonomy\\ttaxid
     sink: ./results/taxonomy-summary/SSU-taxonomy-summary.ttl
     template_name: taxon-info.ldt.ttl

--- a/utils/arup_archive.py
+++ b/utils/arup_archive.py
@@ -68,15 +68,15 @@ subyt:
   - source: 
       path: ./results/taxonomy-summary/LSU/{PREFIX}.merged_LSU.fasta.mseq.tsv
       mime: text/csv
-      delimiter: \\t
-      header: OTU_ID\\tLSU_rRNA\\ttaxonomy\\ttaxid
+      delimiter: "\t"
+      header: "OTU_ID\tLSU_rRNA\ttaxonomy\ttaxid"
     sink: ./results/taxonomy-summary/LSU-taxonomy-summary.ttl
     template_name: taxon-info.ldt.ttl
   - source: 
       path: ./results/taxonomy-summary/SSU/{PREFIX}.merged_SSU.fasta.mseq.tsv
       mime: text/csv
       delimiter: "\t"
-      header: OTU_ID\\tSSU_rRNA\\ttaxonomy\\ttaxid
+      header: "OTU_ID\tSSU_rRNA\ttaxonomy\ttaxid"
     sink: ./results/taxonomy-summary/SSU-taxonomy-summary.ttl
     template_name: taxon-info.ldt.ttl
 """


### PR DESCRIPTION
I think you need to have double quotes here to have \t actually mean tab

since the surrounding triple-quotes """ are in use, no futher escaping of those should be needed

warning: untested code 

this is a suggested fix for the problem in https://github.com/emo-bon/analysis-results-uplifting-docker/issues/25